### PR TITLE
Error out when variable backupTo is undefined

### DIFF
--- a/podio_backup_full_cli.php
+++ b/podio_backup_full_cli.php
@@ -89,13 +89,17 @@ echo "Duration: $total_time minutes.\n";
 
 function check_backup_folder() {
     global $config;
+    if (!isset($config['backupTo'])) {
+	show_error("backupTo variable needs to be defined");
+        exit();
+    }
     $folder = $config['backupTo'];
     if (!is_dir($folder)) {
-        show_error("ERROR: create a backup folder called '" . $folder . "'");
+        show_error("create a backup folder called '" . $folder . "'");
         exit();
     }
     if (!is_writeable($folder)) {
-        show_error("ERROR: please make sure that the " . $folder . " directory is writeable and has 777 permissions set");
+        show_error("please make sure that the " . $folder . " directory is writeable and has 777 permissions set");
         exit();
     }
     if (!file_exists($folder . "/.htaccess")) {


### PR DESCRIPTION
If there is no configuration file, when backupTo is not defined will give a php warning, fixed with this check

````
PHP Notice:  Undefined index: backupTo in /home/bassols/src/podio-backup/podio_backup_full_cli.php on line 92
ERROR: ERROR: create a backup folder called ''
````